### PR TITLE
Add Roger Creasy to list

### DIFF
--- a/list-of-names.md
+++ b/list-of-names.md
@@ -24,3 +24,4 @@ Or your GitHub profile:
 - [Tom Lutz](https://github.com/tommylutz)
 - [Warren Harper](https://twitter.com/warrenharper)
 - [Geostarters](https://github.com/geostarters)
+- [Roger Creasy](https://twitter.com/rogercreasy)


### PR DESCRIPTION
Roger Creasy really should be on this list. So, this fix adds his name and Twitter account.